### PR TITLE
fix: load expect via require for Bun compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,13 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test
+      - name: Test (Node)
         run: pnpm concurrently "pnpm test" "NODE_OPTIONS='--import=tsx/esm' pnpm run --use-node-version=20.20.0 test"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Test (Bun)
+        run: pnpm test:bun

--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ describe('Authentication', () => {
 
 Each file works standalone too — `node tests/auth.ts` runs just that file. The entry point is your test runner, written in plain JavaScript.
 
-> [!NOTE]
-> Under [Bun](https://bun.sh), this auto-nesting doesn't apply: Bun doesn't propagate [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) across dynamic `import()`, so imported files register at the root instead of nesting under the parent. Use the parameterized pattern below, which works on both Node.js and Bun.
-
 ### Parameterized test files
 
 To pass data into a test file, export a function that wraps a `describe()`:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ describe('Authentication', () => {
 
 Each file works standalone too — `node tests/auth.ts` runs just that file. The entry point is your test runner, written in plain JavaScript.
 
+> [!NOTE]
+> Under [Bun](https://bun.sh), this auto-nesting doesn't apply: Bun doesn't propagate [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html) across dynamic `import()`, so imported files register at the root instead of nesting under the parent. Use the parameterized pattern below, which works on both Node.js and Bun.
+
 ### Parameterized test files
 
 To pass data into a test file, export a function that wraps a `describe()`:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	"scripts": {
 		"build": "pkgroll --clean-dist --minify",
 		"test": "node tests/index.ts",
+		"test:bun": "bun tests/index.ts",
 		"lint": "lintroll --git --cache",
 		"type-check": "tsc",
 		"dev": "node --watch -C development tests/index.ts",

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import type {
 	DescribeCallback,
 	Callback,
 } from './types.ts';
-import { consoleError } from './logger.ts';
+import { logError } from './logger.ts';
 import { waitAllPromises } from './utils/wait-all-promises.ts';
 import { createSemaphore } from './utils/semaphore.ts';
 import { timeLimitFunction } from './utils/timer.ts';
@@ -103,7 +103,7 @@ const runDescribe = async (
 		// Apply timeout if specified
 		await timeLimitFunction(inProgress, context.timeout, context.abortController);
 	} catch (error) {
-		consoleError(error);
+		logError(error);
 		process.exitCode = 1;
 	} finally {
 		unlinkAbort?.();
@@ -121,7 +121,7 @@ const runDescribe = async (
 			try {
 				await onFinishCallback();
 			} catch (error) {
-				consoleError(error);
+				logError(error);
 				process.exitCode = 1;
 			}
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import { createRequire } from 'node:module';
+import type { Expect } from 'expect';
+
 export type {
 	Test,
 	Describe,
@@ -8,4 +11,13 @@ export {
 export { test, onTestFail, onTestFinish } from './create-test.ts';
 export { expectSnapshot, configure } from './snapshot/snapshots.ts';
 export { setProcessTimeout } from './process-timeout.ts';
-export { expect } from 'expect';
+
+/**
+ * `expect`'s ESM wrapper (build/index.mjs) re-exports `cjsModule.expect` from a
+ * default import of its CommonJS build. Bun honors the webpack `__esModule`
+ * marker and binds that default import to `module.exports.default` (the
+ * `expect` function itself), so `cjsModule.expect` is `undefined`. Node instead
+ * binds the default to the whole `module.exports` object. Loading the CommonJS
+ * build via `require` resolves identically on both runtimes.
+ */
+export const { expect } = createRequire(import.meta.url)('expect') as { expect: Expect };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -70,6 +70,15 @@ export const logTestFail = (
 	consoleError(`${indentMultiline(inspect(error))}\n`);
 };
 
+/**
+ * Log an error via `inspect()` so the output is identical across runtimes.
+ * Passing a raw `Error` to `console.error` renders differently on Node
+ * (`Error: …`) and Bun (`error: …` with a code frame).
+ */
+export const logError = (error: unknown) => {
+	consoleError(inspect(error));
+};
+
 export const logTestSuccess = (testMeta: TestMeta) => {
 	consoleLog(`${formatTimestamp()} ${successIcon} ${getTestTitle(testMeta)}`);
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -75,9 +75,7 @@ export const logTestFail = (
  * Passing a raw `Error` to `console.error` renders differently on Node
  * (`Error: …`) and Bun (`error: …` with a code frame).
  */
-export const logError = (error: unknown) => {
-	consoleError(inspect(error));
-};
+export const logError = (error: unknown) => consoleError(inspect(error));
 
 export const logTestSuccess = (testMeta: TestMeta) => {
 	consoleLog(`${formatTimestamp()} ${successIcon} ${getTestTitle(testMeta)}`);

--- a/tests/specs/nesting.ts
+++ b/tests/specs/nesting.ts
@@ -46,6 +46,7 @@ describe('nesting', () => {
 		// propagate ALS across dynamic import(), so children are flattened to the
 		// root instead of nesting under the parent. The static/parameterized
 		// pattern (export a function wrapping describe()) works on both runtimes.
+		// https://github.com/oven-sh/bun/issues/32693
 		if (isBun) {
 			skip('Bun drops AsyncLocalStorage across dynamic import()');
 		}

--- a/tests/specs/nesting.ts
+++ b/tests/specs/nesting.ts
@@ -1,6 +1,9 @@
 import { createFixture } from 'fs-fixture';
 import { installManten, node } from '../utils/spec-helpers.ts';
-import { describe, test, expect } from 'manten';
+import { isBun } from '../utils/runtime.ts';
+import {
+	describe, test, expect, skip,
+} from 'manten';
 
 describe('nesting', () => {
 	test('deep context nesting', async () => {
@@ -35,5 +38,38 @@ describe('nesting', () => {
 		expect(testProcess.stdout).toMatch('✔ Level 1 › Level 2 › Level 3 › Test at level 3');
 		expect(testProcess.stdout).toMatch('✔ Level 1 › Level 2 › Level 3 › Level 4 › Test at level 4');
 		expect(testProcess.stdout).toMatch('4 passed');
+	});
+
+	test('nests tests from dynamically imported files', async () => {
+		// Cross-file nesting relies on the imported file's test()/describe()
+		// running within the parent's AsyncLocalStorage context. Bun does not
+		// propagate ALS across dynamic import(), so children are flattened to the
+		// root instead of nesting under the parent. The static/parameterized
+		// pattern (export a function wrapping describe()) works on both runtimes.
+		if (isBun) {
+			skip('Bun drops AsyncLocalStorage across dynamic import()');
+		}
+
+		await using fixture = await createFixture({
+			'child.mjs': `
+			import { test } from 'manten';
+
+			test('imported test', () => {});
+			`,
+			'index.mjs': `
+			import { describe } from 'manten';
+
+			await describe('Parent', async () => {
+				await import('./child.mjs');
+			});
+			`,
+			...installManten,
+		});
+
+		const testProcess = await node(fixture.getPath('index.mjs'));
+
+		expect('exitCode' in testProcess).toBe(false);
+		expect(testProcess.stdout).toMatch('✔ Parent › imported test');
+		expect(testProcess.stdout).toMatch('1 passed');
 	});
 });

--- a/tests/specs/parallel.ts
+++ b/tests/specs/parallel.ts
@@ -537,7 +537,8 @@ describe('parallel', () => {
 			// Dynamically imported suites only join the parent's concurrency
 			// limiter when the parent's AsyncLocalStorage context reaches them.
 			// Bun drops ALS across dynamic import(), so the limit isn't applied
-			// and the ordering guarantee doesn't hold. See README.
+			// and the ordering guarantee doesn't hold.
+			// https://github.com/oven-sh/bun/issues/32693
 			if (isBun) {
 				skip('Bun drops AsyncLocalStorage across dynamic import()');
 			}

--- a/tests/specs/parallel.ts
+++ b/tests/specs/parallel.ts
@@ -1,7 +1,10 @@
 import { createFixture } from 'fs-fixture';
 import { expectMatchInOrder } from '../utils/expect-match-in-order.ts';
 import { installManten, node } from '../utils/spec-helpers.ts';
-import { describe, test, expect } from 'manten';
+import { isBun } from '../utils/runtime.ts';
+import {
+	describe, test, expect, skip,
+} from 'manten';
 
 describe('parallel', () => {
 	describe('parallel: false (sequential)', () => {
@@ -531,6 +534,14 @@ describe('parallel', () => {
 		});
 
 		test('parallel option limits dynamic import suites', async () => {
+			// Dynamically imported suites only join the parent's concurrency
+			// limiter when the parent's AsyncLocalStorage context reaches them.
+			// Bun drops ALS across dynamic import(), so the limit isn't applied
+			// and the ordering guarantee doesn't hold. See README.
+			if (isBun) {
+				skip('Bun drops AsyncLocalStorage across dynamic import()');
+			}
+
 			await using fixture = await createFixture({
 				'suite-a.mjs': `
 				import { setTimeout } from 'node:timers/promises';

--- a/tests/specs/skip.ts
+++ b/tests/specs/skip.ts
@@ -430,7 +430,8 @@ describe('skip', () => {
 		// Detecting a too-late skip() relies on the dynamically imported file's
 		// test() running within the parent's AsyncLocalStorage context. Bun does
 		// not propagate ALS across dynamic import(), so the parent never sees the
-		// child's test register and skip() is (incorrectly) allowed. See README.
+		// child's test register and skip() is (incorrectly) allowed.
+		// https://github.com/oven-sh/bun/issues/32693
 		if (isBun) {
 			skip('Bun drops AsyncLocalStorage across dynamic import()');
 		}

--- a/tests/specs/skip.ts
+++ b/tests/specs/skip.ts
@@ -1,6 +1,9 @@
 import { createFixture } from 'fs-fixture';
 import { installManten, node } from '../utils/spec-helpers.ts';
-import { describe, test, expect } from 'manten';
+import { isBun } from '../utils/runtime.ts';
+import {
+	describe, test, expect, skip,
+} from 'manten';
 
 describe('skip', () => {
 	test('should skip conditionally', async () => {
@@ -424,6 +427,14 @@ describe('skip', () => {
 	});
 
 	test('should error if skip called after dynamic import', async () => {
+		// Detecting a too-late skip() relies on the dynamically imported file's
+		// test() running within the parent's AsyncLocalStorage context. Bun does
+		// not propagate ALS across dynamic import(), so the parent never sees the
+		// child's test register and skip() is (incorrectly) allowed. See README.
+		if (isBun) {
+			skip('Bun drops AsyncLocalStorage across dynamic import()');
+		}
+
 		await using fixture = await createFixture({
 			'child.mjs': `
 			import { test } from 'manten';

--- a/tests/specs/snapshots-serialize.ts
+++ b/tests/specs/snapshots-serialize.ts
@@ -1,5 +1,8 @@
 import { serialize } from '../../src/snapshot/snapshots.ts';
-import { describe, test, expect } from 'manten';
+import { isBun } from '../utils/runtime.ts';
+import {
+	describe, test, expect, skip,
+} from 'manten';
 
 describe('snapshots serialize', () => {
 	test('sorts object keys', () => {
@@ -87,6 +90,13 @@ describe('snapshots serialize', () => {
 	});
 
 	test('handles functions', () => {
+		// Inferring a name for an arrow function assigned to a `const` inside a
+		// nested scope is a V8 behavior; JavaScriptCore (Bun) reports
+		// `[Function (anonymous)]`. This asserts the V8/Node output.
+		if (isBun) {
+			skip('V8-specific function name inference');
+		}
+
 		const function_ = () => {};
 		expect(serialize(function_)).toBe('[Function: function_]');
 

--- a/tests/utils/runtime.ts
+++ b/tests/utils/runtime.ts
@@ -1,0 +1,1 @@
+export const isBun = 'bun' in process.versions;


### PR DESCRIPTION
## Problem

`import { expect } from 'manten'` crashes under [Bun](https://bun.sh) with `TypeError: expect is not a function`. manten re-exports `expect` from the [`expect`](https://www.npmjs.com/package/expect) package, and that re-export resolves to `undefined` on Bun, breaking every test that uses the bundled `expect`.

The cause is a CommonJS interop difference, not a manten bug. `expect`'s ESM wrapper (`build/index.mjs`) reads `cjsModule.expect` from a *default* import of its webpack CJS build, which sets the `__esModule`/`default` markers. Bun honors those markers and binds a default import to `module.exports.default` (the `expect` function itself, which has no `.expect` property), while Node binds it to the whole `module.exports` object. `require('expect')` is consistent on both.

## Changes

- Load `expect` through `createRequire` so the consistent CommonJS resolution is used on both runtimes, typed via the package's `Expect` type. The `expect` package ships no native-ESM entry to import from directly; its only ESM file is the broken wrapper above.
- Route describe and `onFinish` errors through `inspect()` (matching `logTestFail`) so error output is deterministic across runtimes — Bun renders a raw `console.error(Error)` as `error: …` with a code frame, Node as `Error: …`.
- Run the suite under Bun in CI (pinned `oven-sh/setup-bun`, a `test:bun` script, after the Node step) so this regression can't return unnoticed. `bun-version: latest` is intentional, to act as a canary for new Bun releases.
- Skip the few specs that assert engine-specific output (V8-only nested arrow-function name inference) or depend on `AsyncLocalStorage` surviving dynamic `import()`, each with a comment. Add an explicit cross-file dynamic-import nesting test (Node-only) so that path is covered rather than silently untested.

## Not first-class Bun support yet

This fixes the crash and adds a CI canary; it is not a claim of full Bun support. manten's cross-file auto-nesting relies on `AsyncLocalStorage` surviving dynamic `import()`, which Bun currently drops (filed upstream: oven-sh/bun#32693, plus the related segfault oven-sh/bun#32694). Until that's resolved, the static/parameterized split pattern is the Bun-compatible way to split tests across files.
